### PR TITLE
replace Scribble-Server submodule clone type from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server"]
 	path = server
-	url = git@github.com:Scribble-Editor/scribble-server
+	url = http://github.com/Scribble-Editor/Scribble-Server.git


### PR DESCRIPTION
## Changes
- Scribble-Server submodule is now cloned using HTTPS due to Netlify permission issues