### PR TITLE
fix document remaining open when deleting

### DIFF
--- a/client/components/EditorTextarea.vue
+++ b/client/components/EditorTextarea.vue
@@ -93,6 +93,7 @@ export default {
   },
   mounted () {
     this.$root.$on('openDocument', this.openDocument)
+    this.$root.$on('closeDocument', this.closeDocument)
   },
   methods: {
     changeActiveDocument (activeDocument) {
@@ -109,7 +110,9 @@ export default {
     closeDocument (documentName) {
       const documentIndex = this.openedDocuments.indexOf(documentName)
       this.openedDocuments.splice(documentIndex, 1)
-      this.changeActiveDocument(this.openedDocuments[0])
+      if (documentName === this.activeDocument) {
+        this.changeActiveDocument(this.openedDocuments[0])
+      }
       delete (this.openedSessions[documentName])
     },
     openDocument (documentName) {

--- a/client/components/EditorTreeContextmenu.vue
+++ b/client/components/EditorTreeContextmenu.vue
@@ -84,6 +84,7 @@ export default {
     deleteDocument (documentName) {
       this.$store.commit('documents/remove', documentName)
       this.$root.$emit('updateTree')
+      this.$root.$emit('closeDocument', documentName)
     }
   }
 }


### PR DESCRIPTION
## Issues
- Fix #46 Deleting a file that is still open does not close the document in the editor

## Changes
- Close document if deleted
- Only change active document when active document is deleted